### PR TITLE
#43: Add support for Spring Boot 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ so if you find an interesting "Help Wanted" issue then please drop us a line in 
 
 ### Dependencies/Requirements
 * Java 8
-* [Spring Boot](http://projects.spring.io/spring-boot/) 
+* [Spring Boot 2](http://projects.spring.io/spring-boot/) 
 * [Failsafe](https://github.com/jhalterman/failsafe)
 
 ### Running/Using
@@ -76,7 +76,7 @@ public class MyBean {
 }
 ```
 
-The [endpoint](http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html) is reachable via _**http://${yourAddress}/failsafe**_.
+The [endpoint](http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html) is reachable via _**http://${yourAddress}/application/failsafe**_.
 
 The generated output will look like this:
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,19 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
 		<java.version>1.8</java.version>
+		<spring-boot.version>2.0.0.M5</spring-boot.version>
 	</properties>
+
+	<repositories>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/libs-milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 
 	<dependencies>
         <dependency>
@@ -27,7 +39,7 @@
         <dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
-            <version>1.5.2.RELEASE</version>
+            <version>${spring-boot.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -41,13 +53,13 @@
         <dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-            <version>1.5.2.RELEASE</version>
+            <version>${spring-boot.version}</version>
 			<scope>test</scope>
 		</dependency>
         <dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
-            <version>1.5.2.RELEASE</version>
+            <version>${spring-boot.version}</version>
 			<scope>test</scope>
 		</dependency>
         <dependency>

--- a/src/main/java/org/zalando/failsafeactuator/config/FailsafeAutoConfiguration.java
+++ b/src/main/java/org/zalando/failsafeactuator/config/FailsafeAutoConfiguration.java
@@ -13,7 +13,6 @@ package org.zalando.failsafeactuator.config;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
-import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
@@ -55,8 +54,7 @@ public class FailsafeAutoConfiguration {
     }
 
     private boolean isEnabled(ConditionContext context, String prefix, boolean defaultValue) {
-      RelaxedPropertyResolver resolver = new RelaxedPropertyResolver(context.getEnvironment(), prefix);
-      return resolver.getProperty("enabled", Boolean.class, defaultValue);
+      return context.getEnvironment().getProperty(prefix + ".enabled", Boolean.class, defaultValue);
     }
   }
 }

--- a/src/main/java/org/zalando/failsafeactuator/endpoint/FailsafeEndpoint.java
+++ b/src/main/java/org/zalando/failsafeactuator/endpoint/FailsafeEndpoint.java
@@ -12,7 +12,8 @@ package org.zalando.failsafeactuator.endpoint;
 
 import net.jodah.failsafe.CircuitBreaker;
 
-import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.zalando.failsafeactuator.endpoint.domain.CircuitBreakerState;
 import org.zalando.failsafeactuator.service.CircuitBreakerRegistry;
@@ -22,25 +23,23 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Implementation of {@link AbstractEndpoint} for Failsafe purposes.
+ * Implementation of actuator {@link Endpoint} for Failsafe purposes.
  *
  * <p>It will return all names of registered {@link CircuitBreaker}'s and their state as JSON.
  *
  * @author mpickhan on 29.06.16.
  */
 @ConfigurationProperties(prefix = "endpoints.failsafe")
-public class FailsafeEndpoint extends AbstractEndpoint<List<CircuitBreakerState>> {
-
-  private static final String ENDPOINT_ID = "failsafe";
+@Endpoint(id = "failsafe")
+public class FailsafeEndpoint {
   private final CircuitBreakerRegistry circuitBreakerRegistry;
 
   public FailsafeEndpoint(final CircuitBreakerRegistry circuitBreakerRegistry) {
-    super(ENDPOINT_ID);
     this.circuitBreakerRegistry = circuitBreakerRegistry;
   }
 
-  @Override
-  public List<CircuitBreakerState> invoke() {
+  @ReadOperation
+  public List<CircuitBreakerState> listCircuitBreakerStates() {
     final Map<String, CircuitBreaker> breakerMap = this.circuitBreakerRegistry.getConcurrentBreakerMap();
     final List<CircuitBreakerState> breakerStates = new ArrayList<CircuitBreakerState>();
 

--- a/src/test/java/org/zalando/failsafeactuator/endpoint/EndpointTest.java
+++ b/src/test/java/org/zalando/failsafeactuator/endpoint/EndpointTest.java
@@ -15,9 +15,9 @@ import net.jodah.failsafe.CircuitBreaker;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.zalando.failsafeactuator.endpoint.domain.CircuitBreakerState;
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class EndpointTest {
 
-  private static final String FAILSAFE_URL = "http://localhost:%d/failsafe";
+  private static final String FAILSAFE_URL = "http://localhost:%d/application/failsafe";
 
   private static final String BREAKER_NAME = "testBreaker";
 


### PR DESCRIPTION
- Added support for Spring Boot 2.x (2.0.0.M5)
- RelaxedPropertyResolver has been removed in Spring Boot 2. Instead it was advised that properties should be read directly from the environment using uniform format (Ref: https://github.com/spring-projects/spring-boot/wiki/Relaxed-Binding-2.0)
- Spring Boot 2 made some significant changes to Actuator endpoints. The endpoints are now prefixed with "application", and in order to implement custom actuator endpoints they need to be annotated as @Endpoint. (Ref: https://spring.io/blog/2017/08/22/introducing-actuator-endpoints-in-spring-boot-2-0)
- Updated README.md
  - Updated Spring Boot version
  - Updated the failsafe actuator endpoint