### PR TITLE
changed output of endpoint to a more monitoring friendly solution. 

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -8,3 +8,4 @@ Malte Pickhan <malte.pickhan@zalando.de>
 - Jörg Bellmann <jbellmann>
 - Michael Vitz <mvitz>
 - Rob van der Leek <robvanderleek>
+- Jonas Jurczok <jonasjurczok@gmail.com>

--- a/README.md
+++ b/README.md
@@ -82,7 +82,12 @@ The [endpoint](http://docs.spring.io/spring-boot/docs/current/reference/html/pro
 The generated output will look like this:
 
 ```json
-[{"name":"WhatABreak","closed":true,"open":false,"half_open":false}]
+{
+  "WhatABreak": {
+    "name": "WhatABreak",
+    "state": "OPEN"
+  }
+}
 ```
 
 ### How to Build on Your Own

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -3,9 +3,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>org.zalando</groupId>
 	<artifactId>failsafe-actuator</artifactId>
-	<version>0.4.1</version>
 	<packaging>jar</packaging>
 
 	<name>Failsafe-Actuator-Library</name>
@@ -14,7 +12,7 @@
     <parent>
       <groupId>org.zalando</groupId>
 	  <artifactId>failsafe-actuator-parent</artifactId>
-	   <version>0.4.1</version>
+	   <version>0.5.0</version>
     </parent>
 
     <properties>

--- a/library/src/main/java/org/zalando/failsafeactuator/endpoint/FailsafeEndpoint.java
+++ b/library/src/main/java/org/zalando/failsafeactuator/endpoint/FailsafeEndpoint.java
@@ -1,13 +1,15 @@
 package org.zalando.failsafeactuator.endpoint;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import net.jodah.failsafe.CircuitBreaker;
 import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.zalando.failsafeactuator.endpoint.domain.CircuitBreakerState;
 import org.zalando.failsafeactuator.service.CircuitBreakerRegistry;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Implementation of {@link AbstractEndpoint} for Failsafe purposes.
@@ -17,7 +19,7 @@ import org.zalando.failsafeactuator.service.CircuitBreakerRegistry;
  * @author mpickhan on 29.06.16.
  */
 @ConfigurationProperties(prefix = "endpoints.failsafe")
-public class FailsafeEndpoint extends AbstractEndpoint<List<CircuitBreakerState>> {
+public class FailsafeEndpoint extends AbstractEndpoint<Map<String, CircuitBreakerState>> {
 
   private static final String ENDPOINT_ID = "failsafe";
   private final CircuitBreakerRegistry circuitBreakerRegistry;
@@ -28,9 +30,9 @@ public class FailsafeEndpoint extends AbstractEndpoint<List<CircuitBreakerState>
   }
 
   @Override
-  public List<CircuitBreakerState> invoke() {
+  public Map<String, CircuitBreakerState> invoke() {
     final Map<String, CircuitBreaker> breakerMap = circuitBreakerRegistry.getConcurrentBreakerMap();
-    final List<CircuitBreakerState> breakerStates = new ArrayList<>();
+    final Map<String, CircuitBreakerState> breakerStates = new HashMap<>();
 
     final List<String> breakersToRemove = new ArrayList<>();
     for (final String identifier : breakerMap.keySet()) {
@@ -40,8 +42,8 @@ public class FailsafeEndpoint extends AbstractEndpoint<List<CircuitBreakerState>
         breakersToRemove.add(identifier);
       } else {
         final CircuitBreakerState state =
-            new CircuitBreakerState(identifier, breaker.isClosed(), breaker.isOpen(), breaker.getState().equals(CircuitBreaker.State.HALF_OPEN));
-        breakerStates.add(state);
+            new CircuitBreakerState(identifier, breaker.getState());
+        breakerStates.put(identifier, state);
       }
     }
     removeUnreferencedBreakers(breakersToRemove);

--- a/library/src/main/java/org/zalando/failsafeactuator/endpoint/domain/CircuitBreakerState.java
+++ b/library/src/main/java/org/zalando/failsafeactuator/endpoint/domain/CircuitBreakerState.java
@@ -1,26 +1,25 @@
 package org.zalando.failsafeactuator.endpoint.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import net.jodah.failsafe.CircuitBreaker;
 
-/**
- * Represents the state and identifier of an {@link net.jodah.failsafe.CircuitBreaker}.
- *
- * @author mpickhan on 29.06.16.
- */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@ToString
 public class CircuitBreakerState {
 
   private String name;
+  private CircuitBreaker.State state;
 
-  private boolean closed;
+  public CircuitBreakerState() {  }
 
-  private boolean open;
+  public CircuitBreakerState(final String name, final CircuitBreaker.State state) {
 
-  private boolean halfOpen;
+    this.name = name;
+    this.state = state;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public CircuitBreaker.State getState() {
+    return state;
+  }
 }

--- a/library/src/test/java/org/zalando/failsafeactuator/endpoint/FailsafeEndpointTest.java
+++ b/library/src/test/java/org/zalando/failsafeactuator/endpoint/FailsafeEndpointTest.java
@@ -1,0 +1,75 @@
+package org.zalando.failsafeactuator.endpoint;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.jodah.failsafe.CircuitBreaker;
+import org.junit.Test;
+import org.zalando.failsafeactuator.service.CircuitBreakerRegistry;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class FailsafeEndpointTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  private final FailsafeEndpoint endpoint;
+  private final CircuitBreakerRegistry circuitBreakerRegistry;
+
+  public FailsafeEndpointTest() {
+    circuitBreakerRegistry = new CircuitBreakerRegistry();
+    endpoint = new FailsafeEndpoint(circuitBreakerRegistry);
+  }
+
+  @Test
+  public void singleBreakerClosed() throws JsonProcessingException {
+    CircuitBreaker test = circuitBreakerRegistry.getOrCreate("Test");
+    test.close();
+
+    String output = mapper.writeValueAsString(endpoint.invoke());
+
+    verifyBreaker(output, "Test", "CLOSED");
+  }
+
+  @Test
+  public void singleBreakerOpen() throws JsonProcessingException {
+    CircuitBreaker test = circuitBreakerRegistry.getOrCreate("Test");
+    test.open();
+
+    String output = mapper.writeValueAsString(endpoint.invoke());
+
+    verifyBreaker(output, "Test", "OPEN");
+  }
+
+  @Test
+  public void singleBreakerHalfOpen() throws JsonProcessingException {
+    CircuitBreaker test = circuitBreakerRegistry.getOrCreate("Test");
+    test.halfOpen();
+
+    String output = mapper.writeValueAsString(endpoint.invoke());
+
+    verifyBreaker(output, "Test", "HALF_OPEN");
+
+  }
+
+  @Test
+  public void twoBreakersMixedState() throws JsonProcessingException {
+    CircuitBreaker open = circuitBreakerRegistry.getOrCreate("Open");
+    open.open();
+
+    CircuitBreaker closed = circuitBreakerRegistry.getOrCreate("Closed");
+    closed.close();
+
+    String output = mapper.writeValueAsString(endpoint.invoke());
+
+    verifyBreaker(output, "Open", "OPEN");
+    verifyBreaker(output, "Closed", "CLOSED");
+  }
+
+  private void verifyBreaker(final String input, final String name, final String state) {
+    assertThat(input, hasJsonPath("$." + name + ".name", equalTo(name)));
+    assertThat(input, hasJsonPath("$." + name + ".state", equalTo(state)));
+    assertThat(input, hasJsonPath("$." + name + ".length()", equalTo(2)));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zalando</groupId>
     <artifactId>failsafe-actuator-parent</artifactId>
-    <version>0.4.1</version>
+    <version>0.5.0</version>
     <packaging>pom</packaging>
 
     <name>Failsafe-Actuator</name>
@@ -36,14 +36,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <!-- Lombok will not be used on the live system, it is only used when
-                compiling, so we don't package it -->
-            <scope>provided</scope>
-            <version>1.16.18</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>1.5.2.RELEASE</version>
@@ -59,6 +51,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path-assert</artifactId>
+            <version>2.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -4,9 +4,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.zalando</groupId>
     <artifactId>failsafe-actuator-sample</artifactId>
-    <version>0.4.1</version>
 
     <name>Failsafe-Actuator-Sample</name>
     <description>Sample application for Failsafe-Actuator</description>
@@ -14,7 +12,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>failsafe-actuator-parent</artifactId>
-        <version>0.4.1</version>
+        <version>0.5.0</version>
     </parent>
 
     <build>
@@ -38,7 +36,7 @@
         <dependency>
             <groupId>org.zalando</groupId>
             <artifactId>failsafe-actuator</artifactId>
-            <version>0.4.1</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/sample/src/main/java/org/zalando/failsafeactuator/sample/SampleApplication.java
+++ b/sample/src/main/java/org/zalando/failsafeactuator/sample/SampleApplication.java
@@ -7,8 +7,8 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 public class SampleApplication {
 
     public static void main(final String[] args) {
-    final SpringApplicationBuilder applicationBuilder =
-        new SpringApplicationBuilder(SampleApplication.class);
+        final SpringApplicationBuilder applicationBuilder =
+            new SpringApplicationBuilder(SampleApplication.class);
         applicationBuilder.banner(new SampleApplicationBanner()).logStartupInfo(false).run(args);
     }
 

--- a/sample/src/test/java/org/zalando/failsafeactuator/endpoint/EndpointTest.java
+++ b/sample/src/test/java/org/zalando/failsafeactuator/endpoint/EndpointTest.java
@@ -25,9 +25,8 @@ import org.zalando.failsafeactuator.service.FailsafeBreaker;
 
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = org.zalando.failsafeactuator.sample.SampleApplication.class,
@@ -48,18 +47,18 @@ public class EndpointTest {
   @Test
   public void endpointTest() {
     Map<String, CircuitBreakerState> state = fetchCircuitBreaker();
-    assertThat(state.get(BREAKER_NAME), is(not(nullValue())));
-    assertThat(state.get(BREAKER_NAME).getState(), equalTo(CircuitBreaker.State.CLOSED));
+    assertNotEquals(state.get(BREAKER_NAME), null);
+    assertEquals(state.get(BREAKER_NAME).getState(), CircuitBreaker.State.CLOSED);
 
     breaker.open();
     state = fetchCircuitBreaker();
-    assertThat(state.get(BREAKER_NAME), is(not(nullValue())));
-    assertThat(state.get(BREAKER_NAME).getState(), equalTo(CircuitBreaker.State.OPEN));
+    assertNotEquals(state.get(BREAKER_NAME), null);
+    assertEquals(state.get(BREAKER_NAME).getState(), CircuitBreaker.State.OPEN);
 
     breaker.halfOpen();
     state = fetchCircuitBreaker();
-    assertThat(state.get(BREAKER_NAME), is(not(nullValue())));
-    assertThat(state.get(BREAKER_NAME).getState(), equalTo(CircuitBreaker.State.HALF_OPEN));
+    assertNotEquals(state.get(BREAKER_NAME), null);
+    assertEquals(state.get(BREAKER_NAME).getState(), CircuitBreaker.State.HALF_OPEN);
   }
 
   private Map<String, CircuitBreakerState> fetchCircuitBreaker() {


### PR DESCRIPTION
Hi,

we just started to use your lib for our production system and we really love it :)
One small thing we are missing is a more monitoring friendly output to the endpoint.

I changed the output in a way that you can reference each breaker by a name and not just by a (not guaranteed) ordering in a list.

Also one question:
why do you use the failsafe endpoint for cleaning up the registry? I didn't want to change that much, though.. If you want I can also work on this in a future PR.

Greetings from an ex Zalando :wave: 