### PR TITLE
Readded version

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -4,51 +4,51 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>failsafe-actuator</artifactId>
+	<version>0.5.1</version>
 	<packaging>jar</packaging>
 
 	<name>Failsafe-Actuator-Library</name>
-    <description>Failsafe-Actuator provides an out of the box endpoint for Failsafe</description>
+	<description>Failsafe-Actuator provides an out of the box endpoint for Failsafe</description>
 
     <parent>
-      <groupId>org.zalando</groupId>
-	  <artifactId>failsafe-actuator-parent</artifactId>
-	   <version>0.5.0</version>
-    </parent>
+    	<groupId>org.zalando</groupId>
+  		<artifactId>failsafe-actuator-parent</artifactId>
+   		<version>0.5.0</version>
+   	</parent>
 
-    <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
-    </properties>
+	<properties>
+       	<maven.deploy.skip>false</maven.deploy.skip>
+   	</properties>
     
-    <build>
-        <plugins>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.10.4</version>
-            <executions>
-                <execution>
-                    <id>attach-javadocs</id>
-                    <goals>
-                        <goal>jar</goal>
-                    </goals>
-                </execution>
-            </executions>
-        </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <executions>
-                <execution>
-                    <id>sign-artifacts</id>
-                    <phase>verify</phase>
-                    <goals>
-                        <goal>sign</goal>
-                    </goals>
-                </execution>
-            </executions>
-        </plugin>
-        </plugins>
-    </build>
-
+   	<build>
+       	<plugins>
+       		<plugin>
+           		<groupId>org.apache.maven.plugins</groupId>
+           		<artifactId>maven-javadoc-plugin</artifactId>
+           		<version>2.10.4</version>
+           		<executions>
+               		<execution>
+                   		<id>attach-javadocs</id>
+                   		<goals>
+                       		<goal>jar</goal>
+                   		</goals>
+               		</execution>
+           		</executions>
+       		</plugin>
+       		<plugin>
+           		<groupId>org.apache.maven.plugins</groupId>
+           		<artifactId>maven-gpg-plugin</artifactId>
+           		<version>1.6</version>
+           		<executions>
+               		<execution>
+                   		<id>sign-artifacts</id>
+                   		<phase>verify</phase>
+                   		<goals>
+                       		<goal>sign</goal>
+                   		</goals>
+               		</execution>
+          		</executions>
+       		</plugin>
+       	</plugins>
+	</build>
 </project>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -10,45 +10,45 @@
 	<name>Failsafe-Actuator-Library</name>
 	<description>Failsafe-Actuator provides an out of the box endpoint for Failsafe</description>
 
-    <parent>
-    	<groupId>org.zalando</groupId>
-  		<artifactId>failsafe-actuator-parent</artifactId>
-   		<version>0.5.0</version>
-   	</parent>
+	<parent>
+		<groupId>org.zalando</groupId>
+		<artifactId>failsafe-actuator-parent</artifactId>
+		<version>0.5.0</version>
+	</parent>
 
 	<properties>
-       	<maven.deploy.skip>false</maven.deploy.skip>
-   	</properties>
+		<maven.deploy.skip>false</maven.deploy.skip>
+	</properties>
     
-   	<build>
-       	<plugins>
-       		<plugin>
-           		<groupId>org.apache.maven.plugins</groupId>
-           		<artifactId>maven-javadoc-plugin</artifactId>
-           		<version>2.10.4</version>
-           		<executions>
-               		<execution>
-                   		<id>attach-javadocs</id>
-                   		<goals>
-                       		<goal>jar</goal>
-                   		</goals>
-               		</execution>
-           		</executions>
-       		</plugin>
-       		<plugin>
-           		<groupId>org.apache.maven.plugins</groupId>
-           		<artifactId>maven-gpg-plugin</artifactId>
-           		<version>1.6</version>
-           		<executions>
-               		<execution>
-                   		<id>sign-artifacts</id>
-                   		<phase>verify</phase>
-                   		<goals>
-                       		<goal>sign</goal>
-                   		</goals>
-               		</execution>
-          		</executions>
-       		</plugin>
-       	</plugins>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.10.4</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>1.6</version>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
By accident I broke your deployment process.

Due to the missing concrete version in the pom maven will attempt to resolve the parent to inherit the version. This will happen on every build/dependency update. Since you are not deploying the parent to central (for good reason) this breaks on the client machines (it probably only works on your machine because of your local repository).

I readded the version and please do a quick redeployment of this thing :) Thanks and sorry
Jonas

P.S. the indent fixes are because of the online editor of github.. the code looks REALLY strange in it.