### PR TITLE
maven needs the group

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -3,8 +3,9 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
+	<groupId>org.zalando</groupId>
 	<artifactId>failsafe-actuator</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<packaging>jar</packaging>
 
 	<name>Failsafe-Actuator-Library</name>


### PR DESCRIPTION
Hi, me again :)

Apparently maven also needs the group to be able to not lookup the parent every single time -.-

So we are back to the full identifier set in the library pom, but this should make it work for everyone again (tm) -.-